### PR TITLE
fix: value of FileLoader overwritten by viaLoader

### DIFF
--- a/octoploy/config/BaseConfig.py
+++ b/octoploy/config/BaseConfig.py
@@ -61,9 +61,9 @@ class BaseConfig(YmlConfig):
                 if loader_name is not None:
                     loader = ValueLoaderFactory.create(self, value['loader'])
                     new_values = loader.load(value)
+                    new_items[key] = 'viaLoader'
                     for new_key, new_val in new_values.items():
                         new_items[key + new_key] = new_val
-                    new_items[key] = 'viaLoader'
                     continue
 
         items.update(new_items)


### PR DESCRIPTION
When using the file loader `new_key` is `''` so the value will be overwritten by `new_items[key] = 'viaLoader'`.