### PR TITLE
feat(processing): value loading indent

### DIFF
--- a/octoploy/processing/ValueLoader.py
+++ b/octoploy/processing/ValueLoader.py
@@ -45,6 +45,11 @@ class FileLoader(ValueLoader):
         if conversion is not None:
             if conversion == 'base64':
                 return {'': base64.b64encode(content).decode('utf-8')}
+            if conversion.startswith("indent") and conversion[6:].isdigit():
+                indent = int(conversion[6:])
+                content = content.decode(encoding).replace('\n', '\n' + ' ' * indent)
+                return {'': content}
+
             raise ValueError(f'Unknown conversion {conversion}')
 
         return {'': content.decode(encoding)}


### PR DESCRIPTION
This feature adds the option to add indentation for loaded variables.

The use case why this is needed is e.g for crossplane patch-and-transform, where

```yaml
  vcluster_statefulset:
    loader: file
    conversion: indent8
    file: manifests/stateful-set.yml
```

This allows the `forProvider` to be correctly ident the variable from file while not having to keep a file which is weirdly indentted.

```yaml
      - name: statefulset
        base:
          apiVersion: kubernetes.crossplane.io/v1alpha1
          kind: Object
          spec:
            providerRef:
              name: provider-kubernetes
            forProvider:
              manifest: ${vcluster_statefulset}
        patches:
        ...
```